### PR TITLE
Bundle IDs and tags should be a set

### DIFF
--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -87,9 +87,10 @@
                                        ::provenance))
 
 (s/def ::tags
-  (api-spec-array (s/coll-of sc/not-empty-string :distinct true :into #{}) "string"))
+  (api-spec-set (s/coll-of sc/not-empty-string set?) "string"))
+
 (s/def ::bundled-ids
-  (api-spec-array (s/coll-of sc/uuid? :distinct true :into #{}) "string"))
+  (api-spec-set (s/coll-of sc/uuid? set?) "string"))
 
 ;; TODO improve these
 (s/def ::segmentations (s/coll-of (s/keys)))

--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -87,10 +87,10 @@
                                        ::provenance))
 
 (s/def ::tags
-  (api-spec-set (s/coll-of sc/not-empty-string set?) "string"))
+  (api-spec-set (s/coll-of sc/not-empty-string :kind set?) "string"))
 
 (s/def ::bundled-ids
-  (api-spec-set (s/coll-of sc/uuid? set?) "string"))
+  (api-spec-set (s/coll-of sc/uuid? :kind set?) "string"))
 
 ;; TODO improve these
 (s/def ::segmentations (s/coll-of (s/keys)))

--- a/src/kixi/spec.clj
+++ b/src/kixi/spec.clj
@@ -20,6 +20,14 @@
                     :json-schema/type "array"
                     :json-schema/items {:type ~typename}}))
 
+(defmacro api-spec-set
+  [symb typename]
+  `(st/create-spec {:spec ~symb
+                    :form '~symb
+                    :json-schema/type "array"
+                    :json-schema/items {:type ~typename
+                                        :uniqueItems true}}))
+
 (defmacro api-spec-explicit
   ([symb spec]
    `(st/create-spec (merge {:spec ~symb


### PR DESCRIPTION
By not having them as a set (ie. an array) we effectively change the event.  This has broken the datastore in places.