### PR TITLE
Add `destination` and `source` rejected specs

### DIFF
--- a/src/kixi/mailer/reject.clj
+++ b/src/kixi/mailer/reject.clj
@@ -9,3 +9,6 @@
     :service-error})
 
 (s/def ::explain spec/string?)
+
+(s/def ::source spec/any?)
+(s/def ::destination spec/any?)


### PR DESCRIPTION
These specs are introduced in order to make the event more relaxed